### PR TITLE
Add repo sync github workflow

### DIFF
--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -1,0 +1,25 @@
+on:
+  schedule:
+    # runs every monday at 00:00 UTC
+    - cron:  "0 0 * * 1"
+
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/repo_sync.yml'
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: repo-sync
+        uses: repo-sync/github-sync@v2
+        with:
+          source_repo: "https://github.com/thanos-io/thanos"
+          source_branch: "*"
+          destination_branch: "*"
+          sync_tags: "true"
+          github_token: ${{ secrets.SYNC_SECRET }}

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # runs every monday at 00:00 UTC
-    - cron:  "0 0 * * 1"
+    # runs everyday at 00:00 UTC
+    - cron:  "0 0 * * *"
 
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -19,7 +19,7 @@ jobs:
         uses: repo-sync/github-sync@v2
         with:
           source_repo: "https://github.com/thanos-io/thanos"
-          source_branch: "*"
-          destination_branch: "*"
+          source_branch: "main"
+          destination_branch: "main"
           sync_tags: "true"
           github_token: ${{ secrets.SYNC_SECRET }}


### PR DESCRIPTION
Added a github workflow to sync tags from upstream and the main branch. 
mco_repo_sync is the default branch that will hold the konflux builds and this workflow. 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
